### PR TITLE
Debian Compatibilty

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 class twemproxy::config inherits twemproxy {
 
   if $twemproxy::package_manage {
-    file { '/etc/default/${twemproxy::package_name}':
+    file { "/etc/default/${twemproxy::package_name}":
       owner   => 'root',
       group   => 'root',
       mode    => '0644',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 class twemproxy::config inherits twemproxy {
 
   if $twemproxy::package_manage {
-    file { '/etc/default/twemproxy':
+    file { '/etc/default/${twemproxy::package_name}':
       owner   => 'root',
       group   => 'root',
       mode    => '0644',

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -1,1 +1,2 @@
 DAEMON_ARGS='-c /etc/nutcracker.yml'
+DAEMON_OPTS=$DAEMON_ARGS


### PR DESCRIPTION
- Added DAEMON_OPTS alias in default-config, which is used by Debians init.d script
- Changed filename of default-config to use $package_name instead of fix "twemproxy"
